### PR TITLE
Add makefile to clone and install core repo and Fix core logging import.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,6 @@
+install_core:
+	-git clone git@github.com:spendnetwork/core.git ../core
+
+install: install_core
+	pipenv install
+	pip install -e ../core

--- a/runfile.py
+++ b/runfile.py
@@ -11,10 +11,7 @@ import sys
 import pdb
 from logging.handlers import SysLogHandler
 
-if sys.platform == 'linux':
-    from ..git.core.logging_config import add_papertrail_logging_to_webapps, config_stdout_root_logger_with_papertrail
-else:
-    from core.logging_config import add_papertrail_logging_to_webapps, config_stdout_root_logger_with_papertrail
+from core.logging_config import add_papertrail_logging_to_webapps, config_stdout_root_logger_with_papertrail
 
 
 def getInputArgs(rootdir, args=None):


### PR DESCRIPTION
We would ideally put the core requirement in the `Pipfile`, but this requires storing the read-only snbot user github username/password in the Pipfile. 
Since your base repo is public we can't put credentials in, so I've added this workaround that will clone the core repo and install it using a `make` command.
Now with pipenv working we can set up the environment just with 
`make install`

